### PR TITLE
Meta Data Processing Utilities

### DIFF
--- a/include/twilio_web.hrl
+++ b/include/twilio_web.hrl
@@ -1,59 +1,60 @@
 %% Twilio records
 -record(twilio_called,
         {
-          called_number,
-          called_city,
-          called_zip,
-          called_state,
-          called_country,
-          called_country_code,
-          called_prefix
+          called_number       = [],
+          called_city         = [],
+          called_zip          = [],
+          called_state        = [],
+          called_country      = [],
+          called_country_code = [],
+          called_prefix       = []
          }).
 
 -record(twilio_caller,
         {
-          caller_number,
-          caller_city,
-          caller_zip,
-          caller_state,
-          caller_country,
-          caller_country_code,
-          caller_prefix
+          caller_number       = [],
+          caller_city         = [],
+          caller_zip          = [],
+          caller_state        = [],
+          caller_country      = [],
+          caller_country_code = [],
+          caller_prefix       = []
          }).
 
 -record(twilio_from,
         {
-          from_number,
-          from_city,
-          from_zip,
-          from_state,
-          from_country,
-          from_country_code,
-          from_prefix
+          from_number       = [],
+          from_city         = [],
+          from_zip          = [],
+          from_state        = [],
+          from_country      = [],
+          from_country_code = [],
+          from_prefix       = []
          }).
 
 -record(twilio_to,
         {
-          to_number,
-          to_city,
-          to_zip,
-          to_state,
-          to_country,
-          to_country_code,
-          to_prefix
+          to_number       = [],
+          to_city         = [],
+          to_zip          = [],
+          to_state        = [],
+          to_country      = [],
+          to_country_code = [],
+          to_prefix       = []
          }).
 
 -record(twilio,
         {
-          account_sid,
-          direction,
-          call_status,
-          call_sid,
-          api_version,
-          called = #twilio_called{},
-          caller = #twilio_caller{},
-          from = #twilio_from{},
-          to = #twilio_to{}
+          account_sid     = [],
+          application_sid = [],
+          direction       = [],
+          call_status     = [],
+          call_sid        = [],
+          api_version     = [],
+          called          = #twilio_called{},
+          caller          = #twilio_caller{},
+          from            = #twilio_from{},
+          to              = #twilio_to{}
          }).
 
 % Country Codes For Lookup

--- a/src/twilio_web_util.erl
+++ b/src/twilio_web_util.erl
@@ -11,6 +11,8 @@
 
 -include("twilio_web.hrl").
 
+-define(UQ, mochiweb_util:unquote).
+
 process_body(Binary) ->
     List = binary_to_list(Binary),
     Elements = string:tokens(List, "&"),
@@ -28,68 +30,72 @@ make_r([], Twilio, Called, Caller, From, To) ->
                   to = fix_up_number(To)};
 % main twilio record
 make_r([{"AccountSid", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw#twilio{account_sid = Val}, Cd, Cr, Fr, To);
+    make_r(T, Tw#twilio{account_sid = ?UQ(Val)}, Cd, Cr, Fr, To);
+make_r([{"ApplicationSid", Val} | T], Tw, Cd, Cr, Fr, To) ->
+    make_r(T, Tw#twilio{application_sid = ?UQ(Val)}, Cd, Cr, Fr, To);
 make_r([{"ApiVersion", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw#twilio{api_version = Val}, Cd, Cr, Fr, To);
+    make_r(T, Tw#twilio{api_version = ?UQ(Val)}, Cd, Cr, Fr, To);
 make_r([{"Direction", Val}  | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw#twilio{direction = Val},   Cd, Cr, Fr, To);
+    make_r(T, Tw#twilio{direction = ?UQ(Val)},   Cd, Cr, Fr, To);
 make_r([{"CallSid", Val}    | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw#twilio{call_sid = Val},    Cd, Cr, Fr, To);
+    make_r(T, Tw#twilio{call_sid = ?UQ(Val)},    Cd, Cr, Fr, To);
 make_r([{"CallStatus", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw#twilio{call_status = Val}, Cd, Cr, Fr, To);
+    make_r(T, Tw#twilio{call_status = ?UQ(Val)}, Cd, Cr, Fr, To);
 % called records
 make_r([{"Called", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd#twilio_called{called_number = Val}, Cr, Fr, To);
+    make_r(T, Tw, Cd#twilio_called{called_number = ?UQ(Val)}, Cr, Fr, To);
 make_r([{"CalledCity", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd#twilio_called{called_city = Val}, Cr, Fr, To);
+    make_r(T, Tw, Cd#twilio_called{called_city = ?UQ(Val)}, Cr, Fr, To);
 make_r([{"CalledCountry", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd#twilio_called{called_country_code = Val}, Cr, Fr, To);
+    make_r(T, Tw, Cd#twilio_called{called_country_code = ?UQ(Val)}, Cr, Fr, To);
 make_r([{"CalledState", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd#twilio_called{called_state = Val}, Cr, Fr, To);
+    make_r(T, Tw, Cd#twilio_called{called_state = ?UQ(Val)}, Cr, Fr, To);
 make_r([{"CalledZip", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd#twilio_called{called_zip = Val}, Cr, Fr, To);
+    make_r(T, Tw, Cd#twilio_called{called_zip = ?UQ(Val)}, Cr, Fr, To);
 % caller records
 make_r([{"Caller", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr#twilio_caller{caller_number = Val}, Fr, To);
+    make_r(T, Tw, Cd, Cr#twilio_caller{caller_number = ?UQ(Val)}, Fr, To);
 make_r([{"CallerCity", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr#twilio_caller{caller_city = Val}, Fr, To);
+    make_r(T, Tw, Cd, Cr#twilio_caller{caller_city = ?UQ(Val)}, Fr, To);
 make_r([{"CallerCountry", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr#twilio_caller{caller_country_code = Val}, Fr, To);
+    make_r(T, Tw, Cd, Cr#twilio_caller{caller_country_code = ?UQ(Val)}, Fr, To);
 make_r([{"CallerState", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr#twilio_caller{caller_state = Val}, Fr, To);
+    make_r(T, Tw, Cd, Cr#twilio_caller{caller_state = ?UQ(Val)}, Fr, To);
 make_r([{"CallerZip", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr#twilio_caller{caller_zip = Val}, Fr, To);
+    make_r(T, Tw, Cd, Cr#twilio_caller{caller_zip = ?UQ(Val)}, Fr, To);
 % from records
 make_r([{"From", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_number = Val}, To);
+    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_number = ?UQ(Val)}, To);
 make_r([{"FromCity", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_city = Val}, To);
+    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_city = ?UQ(Val)}, To);
 make_r([{"FromCountry", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_country_code = Val}, To);
+    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_country_code = ?UQ(Val)}, To);
 make_r([{"FromState", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_state = Val}, To);
+    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_state = ?UQ(Val)}, To);
 make_r([{"FromZip", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_zip = Val}, To);
+    make_r(T, Tw, Cd, Cr, Fr#twilio_from{from_zip = ?UQ(Val)}, To);
 % To records
 make_r([{"To", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_number = Val});
+    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_number = ?UQ(Val)});
 make_r([{"ToCity", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_city = Val});
+    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_city = ?UQ(Val)});
 make_r([{"ToCountry", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_country_code = Val});
+    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_country_code = ?UQ(Val)});
 make_r([{"ToState", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_state = Val});
+    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_state = ?UQ(Val)});
 make_r([{"ToZip", Val} | T], Tw, Cd, Cr, Fr, To) ->
-    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_zip = Val}).
+    make_r(T, Tw, Cd, Cr, Fr, To#twilio_to{to_zip = ?UQ(Val)}).
 
 % these records all have the same structure so use that
-fix_up_number({Rec, Number, City, Zip, State, undefined, CC, undefined}) ->
+fix_up_number({Rec, Number, City, Zip, State, [], [], []} = R) ->
+    R;
+fix_up_number({Rec, Number, City, Zip, State, [], CC, []}) ->
     {Country, CC, Prefix} = lists:keyfind(CC, 2, ?CCLOOKUP),
     NewPrefix = integer_to_list(Prefix),
     {Rec, fix(Number, NewPrefix), City, Zip, State,
      Country, CC, "+" ++ NewPrefix}.
 
-fix("%2B" ++ Number, CC) ->
+fix("+" ++ Number, CC) ->
     "0" ++ re:replace(Number, "^" ++ CC, "", [{return, list}]).
 
 process([], Acc) -> Acc;


### PR DESCRIPTION
Takes the metadata and:
- turns it into Erlang Records
- expands the short code (TT) into the country name (Trinidad and Tobago)
  and adds that
- breaks out the dialling code eg +447776251669 into +44 and 07776 251669

Ryan, should probably get worked into the example web browser but I am still working on it.
